### PR TITLE
Prevent stale `dataByInput` from being used when calculating total XP

### DIFF
--- a/src/components/EncounterMonsterPanel.tsx
+++ b/src/components/EncounterMonsterPanel.tsx
@@ -55,9 +55,9 @@ const MonsterEncounterPanel = (
     const updatedDataByInput = { ...dataByInput };
     delete updatedDataByInput[id];
     setDataByInput(updatedDataByInput);
-
-    onMonsterXPChange(getTotalXP(dataByInput));
+    onMonsterXPChange(getTotalXP(updatedDataByInput));
   };
+
   return (
     <>
       <table>


### PR DESCRIPTION
💀