### PR TITLE
Store character count and level in `localStorage`

### DIFF
--- a/src/components/Encounter.tsx
+++ b/src/components/Encounter.tsx
@@ -4,6 +4,12 @@ import styled from 'styled-components';
 import calculatePartyXPThresholds, {
   xpThreshold,
 } from '../util/calculatePartyXPThresholds';
+import {
+  getPersistedCharCount,
+  getPersistedCharLevel,
+  persistCharCount,
+  persistCharLevel,
+} from '../util/localStorage';
 import InlineInput from './styled/InlineInput';
 import EncounterMonsterPanel from './EncounterMonsterPanel';
 
@@ -29,12 +35,32 @@ const Encounter = (props: EncounterProps): JSX.Element => {
   const [charCount, setCharCount] = useState<string>('1');
   const [charLevel, setCharLevel] = useState<string>('1');
 
+  useEffect(() => {
+    const savedCharCount = getPersistedCharCount();
+    if (savedCharCount !== charCount) {
+      setCharCount(savedCharCount);
+    }
+
+    const savedCharLevel = getPersistedCharLevel();
+    if (savedCharLevel !== charLevel) {
+      setCharLevel(savedCharLevel);
+    }
+  }, []);
+
   const handleCharCountChange = useCallback(
-    (evt: FormEvent<HTMLInputElement>) => setCharCount(evt.currentTarget.value),
+    (evt: FormEvent<HTMLInputElement>) => {
+      const newCount = evt.currentTarget.value;
+      setCharCount(newCount);
+      persistCharCount(newCount);
+    },
     [setCharCount],
   );
   const handleCharLevelChange = useCallback(
-    (evt: FormEvent<HTMLInputElement>) => setCharLevel(evt.currentTarget.value),
+    (evt: FormEvent<HTMLInputElement>) => {
+      const newLevel = evt.currentTarget.value;
+      setCharLevel(newLevel);
+      persistCharLevel(newLevel);
+    },
     [setCharLevel],
   );
 

--- a/src/components/PartyDetails.tsx
+++ b/src/components/PartyDetails.tsx
@@ -1,0 +1,50 @@
+import React, { FormEvent } from 'react';
+
+import InlineInput from './styled/InlineInput';
+
+interface PartyDetailsProps {
+  charCount: string;
+  charLevel: string;
+  onCharCountChange(evt: FormEvent<HTMLInputElement>): void;
+  onCharLevelChange(evt: FormEvent<HTMLInputElement>): void;
+}
+
+const PartyDetails = (props: PartyDetailsProps): JSX.Element => {
+  const { charCount, charLevel, onCharCountChange, onCharLevelChange } = props;
+
+  return (
+    <React.Fragment>
+      <h2>Enter party details</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Character count</th>
+            <th>Level</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>
+              <InlineInput
+                name="charCount"
+                onChange={onCharCountChange}
+                type="text"
+                value={charCount}
+              />
+            </td>
+            <td>
+              <InlineInput
+                name="charLevel"
+                onChange={onCharLevelChange}
+                type="text"
+                value={charLevel}
+              />
+            </td>
+          </tr>
+        </tbody>
+      </table>
+    </React.Fragment>
+  );
+};
+
+export default PartyDetails;

--- a/src/util/localStorage.ts
+++ b/src/util/localStorage.ts
@@ -1,0 +1,27 @@
+export const persistCharLevel = (level: string): void => {
+  const storage = window.localStorage;
+  storage.setItem('characterLevel', level);
+};
+
+export const getPersistedCharLevel = (): string => {
+  const storage = window.localStorage;
+  const level = storage.getItem('characterLevel');
+  if (level) {
+    return level;
+  }
+  return '1';
+};
+
+export const persistCharCount = (count: string): void => {
+  const storage = window.localStorage;
+  storage.setItem('characterCount', count);
+};
+
+export const getPersistedCharCount = (): string => {
+  const storage = window.localStorage;
+  const count = storage.getItem('characterCount');
+  if (count) {
+    return count;
+  }
+  return '1';
+};


### PR DESCRIPTION
It might make more sense to do the persisting in a [`window.beforeunload`](https://developer.mozilla.org/en-US/docs/Web/API/WindowEventHandlers/onbeforeunload) callback to minimize writes to `localStorage`, but in the current world where the root (or any) component doesn't have access to all the character/monster state, appending a bunch of `beforeunload` listeners (one in `Encounter` and one in `EncounterMonsterPanel`) doesn't feel much cleaner.

### To-dos
- [ ] do the same for monster column (probably less valuable but still)